### PR TITLE
add bluebird to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "author": "GitToken",
   "license": "MIT",
   "dependencies": {
+    "bluebird": "^3.5.0",
     "web3": "^0.19.0"
   }
 }


### PR DESCRIPTION
Add bluebird to package.json dependencies.

Noticed it was missing on install

